### PR TITLE
Fix scenario where db_hash = None on close

### DIFF
--- a/django_s3_sqlite/base.py
+++ b/django_s3_sqlite/base.py
@@ -114,6 +114,7 @@ class DatabaseWrapper(DatabaseWrapper):
             self.s3.Object(
                 self.settings_dict["BUCKET"], self.settings_dict["REMOTE_NAME"],
             ).put(Body=file_bytes, ContentMD5=base64.b64encode(binascii.unhexlify(current_md5)).decode("utf-8"))
+            self.db_hash = current_md5
             log.debug("Saved to remote DB!")
         except Exception as e:
             log.exception("An error occurred pushing the database to S3.")

--- a/django_s3_sqlite/base.py
+++ b/django_s3_sqlite/base.py
@@ -1,12 +1,27 @@
-from django.db.backends.sqlite3.base import DatabaseWrapper
-
+import base64
+import binascii
+import logging
 from hashlib import md5
-from io import BytesIO
-from logging import debug as logging_debug
 from os import path
 
 import boto3
 import botocore
+from django.db.backends.sqlite3.base import DatabaseWrapper
+
+log = logging.getLogger(__name__)
+
+
+def _get_md5(file_bytes: bytes) -> str:
+    """Given bytes, calculate their md5 hash"""
+    m = md5()
+    m.update(file_bytes)
+    return m.hexdigest()
+
+
+def _get_bytes(filename: str) -> bytes:
+    """Read file as bytes"""
+    with open(filename, "rb") as f:
+        return f.read()
 
 
 class DatabaseWrapper(DatabaseWrapper):
@@ -20,51 +35,41 @@ class DatabaseWrapper(DatabaseWrapper):
         Load the database from the S3 storage bucket into the current AWS Lambda
         instance.
         """
-        signature_version = self.settings_dict.get("SIGNATURE_VERSION", "s3v4")
-        s3 = boto3.resource(
-            "s3", config=botocore.client.Config(signature_version=signature_version)
-        )
 
         if "/tmp/" not in self.settings_dict["NAME"]:
+            local_file_path = "/tmp/" + self.settings_dict["NAME"]
+            if path.isfile(local_file_path):
+                current_md5 = _get_md5(_get_bytes(local_file_path))
+            else:
+                current_md5 = ""
             try:
-                etag = ""
-                if path.isfile("/tmp/" + self.settings_dict["NAME"]):
-                    m = md5()
-                    with open("/tmp/" + self.settings_dict["NAME"], "rb") as f:
-                        m.update(f.read())
-
-                    # In general the ETag is the md5 of the file, in some cases it's
-                    # not, and in that case we will just need to reload the file,
-                    # I don't see any other way
-                    etag = m.hexdigest()
-
-                obj = s3.Object(
-                    self.settings_dict["BUCKET"], self.settings_dict["NAME"]
-                )
-                obj_bytes = obj.get(IfNoneMatch=etag)[
+                # In general the ETag is the md5 of the file, in some cases it's
+                # not, and in that case we will just need to reload the file,
+                # I don't see any other way
+                obj_bytes = self.s3.Object(
+                    self.settings_dict["BUCKET"], self.settings_dict["NAME"],
+                ).get(IfNoneMatch=current_md5,)[
                     "Body"
                 ]  # Will throw E on 304 or 404
 
-                with open("/tmp/" + self.settings_dict["NAME"], "wb") as f:
-                    f.write(obj_bytes.read())
-
-                m = md5()
-                with open("/tmp/" + self.settings_dict["NAME"], "rb") as f:
-                    m.update(f.read())
-
-                self.db_hash = m.hexdigest()
+                # Remote does not match local. Replace local copy.
+                with open(local_file_path, "wb") as f:
+                    file_bytes = obj_bytes.read()
+                    self.db_hash = _get_md5(file_bytes)
+                    f.write(file_bytes)
+                    log.debug("Database downloaded from S3.")
 
             except botocore.exceptions.ClientError as e:
                 if e.response["Error"]["Code"] == "304":
-                    logging_debug(
-                        "ETag matches md5 of local copy, using local copy of DB!"
+                    log.debug(
+                        "ETag matches md5 of local copy, using local copy of DB!",
                     )
-                    self.db_hash = etag
+                    self.db_hash = current_md5
                 else:
-                    logging_debug("Couldn't load remote DB object.")
+                    log.exception("Couldn't load remote DB object.")
             except Exception as e:
                 # Weird one
-                logging_debug(e)
+                log.exception("An unexpected error occurred.")
 
         # SQLite DatabaseWrapper will treat our tmp as normal now
         # Check because Django likes to call this function a lot more than it should
@@ -76,10 +81,16 @@ class DatabaseWrapper(DatabaseWrapper):
         if not path.isfile(self.settings_dict["NAME"]):
             open(self.settings_dict["NAME"], "a").close()
 
-        logging_debug("Loaded remote DB!")
+        if self.db_hash is None:
+            self.db_hash = _get_md5(_get_bytes(self.settings_dict["NAME"]))
+        log.debug("Local database is ready. md5:%s", self.db_hash)
 
     def __init__(self, *args, **kwargs):
         super(DatabaseWrapper, self).__init__(*args, **kwargs)
+        signature_version = self.settings_dict.get("SIGNATURE_VERSION", "s3v4")
+        self.s3 = boto3.resource(
+            "s3", config=botocore.client.Config(signature_version=signature_version),
+        )
         self.db_hash = None
         self.load_remote_db()
 
@@ -89,30 +100,20 @@ class DatabaseWrapper(DatabaseWrapper):
         """
         super(DatabaseWrapper, self).close(*args, **kwargs)
 
-        signature_version = self.settings_dict.get("SIGNATURE_VERSION", "s3v4")
-        s3 = boto3.resource(
-            "s3", config=botocore.client.Config(signature_version=signature_version)
+        file_bytes = _get_bytes(self.settings_dict["NAME"])
+        current_md5 = _get_md5(file_bytes)
+        if self.db_hash == current_md5:
+            log.debug("Database unchanged, not saving to remote DB!")
+            return
+        log.debug(
+            "Current md5:%s, Expected md5:%s. Database changed, pushing to S3.",
+            current_md5,
+            self.db_hash,
         )
-
         try:
-            with open(self.settings_dict["NAME"], "rb") as f:
-                fb = f.read()
-
-                m = md5()
-                m.update(fb)
-                if self.db_hash == m.hexdigest():
-                    logging_debug("Database unchanged, not saving to remote DB!")
-                    return
-
-                bytesIO = BytesIO()
-                bytesIO.write(fb)
-                bytesIO.seek(0)
-
-                s3_object = s3.Object(
-                    self.settings_dict["BUCKET"], self.settings_dict["REMOTE_NAME"]
-                )
-                s3_object.put("rb", Body=bytesIO)
+            self.s3.Object(
+                self.settings_dict["BUCKET"], self.settings_dict["REMOTE_NAME"],
+            ).put(Body=file_bytes, ContentMD5=base64.b64encode(binascii.unhexlify(current_md5)).decode("utf-8"))
+            log.debug("Saved to remote DB!")
         except Exception as e:
-            logging_debug(e)
-
-        logging_debug("Saved to remote DB!")
+            log.exception("An error occurred pushing the database to S3.")


### PR DESCRIPTION
If the NAME was already patched, `load_remote_db` would never set
self.db_hash. This caused the comparison to always fail during `close`
and the DB to unnecessarily be uploaded.

This also introduces more logging using the `django_s3_sqlite` namespace
to make it easier to turn on/off for debugging.

Some helper functions were added to make the code more succinct while
also avoiding ever reading the file into memory more than once for a
given method.

Since we already have it, the MD5 sum is pushed to S3 to ensure the
integrity of the upload.