### PR TITLE
Allows for Customization of boto3.resource endpoint_url in Django Settings

### DIFF
--- a/django_s3_sqlite/base.py
+++ b/django_s3_sqlite/base.py
@@ -90,6 +90,7 @@ class DatabaseWrapper(DatabaseWrapper):
         signature_version = self.settings_dict.get("SIGNATURE_VERSION", "s3v4")
         self.s3 = boto3.resource(
             "s3", config=botocore.client.Config(signature_version=signature_version),
+            endpoint_url=self.settings_dict.get("ENDPOINT_URL")
         )
         self.db_hash = None
         self.load_remote_db()


### PR DESCRIPTION
Specifies endpoint_url parameter by including ENDPOINT_URL key in Django DATABASES setting. This will allow users to use this library to connect to Google Cloud Storage.For example:

DATABASES = {
    "default": {
        "ENGINE": "django_s3_sqlite",
        "NAME": "sqlite.db,
        "BUCKET": "your-db-bucket",
        "ENDPOINT_URL": "https://storage.googleapis.com",
    }
}

Note: User must replace AWS access key ID and AWS secret access key with corresponding Google Cloud Storage access ID and secret (collectively called Cloud Storage HMAC key).

[Reference](https://cloud.google.com/storage/docs/migrating#migration-simple)
