### PR TITLE
add 3rd party S3 compatible (non-AWS) support

### DIFF
--- a/django_s3_sqlite/base.py
+++ b/django_s3_sqlite/base.py
@@ -88,8 +88,11 @@ class DatabaseWrapper(DatabaseWrapper):
     def __init__(self, *args, **kwargs):
         super(DatabaseWrapper, self).__init__(*args, **kwargs)
         signature_version = self.settings_dict.get("SIGNATURE_VERSION", "s3v4")
+        endpoint_url = self.settings_dict.get("ENDPOINT_URL")
         self.s3 = boto3.resource(
-            "s3", config=botocore.client.Config(signature_version=signature_version),
+            "s3",
+            config=botocore.client.Config(signature_version=signature_version),
+            endpoint_url=endpoint_url,
         )
         self.db_hash = None
         self.load_remote_db()


### PR DESCRIPTION
Added support for settings that let you use S3 compatible services like Digital Ocean Spaces.

To use:

Set ENVs: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_DEFAULT_REGION`.

Then in your settings like:

```python
DATABASES = {
    "default": {
        "ENGINE": "django_s3_sqlite",
        "NAME": "file_name.db3",
        "BUCKET": "bucket_name",
        "ENDPOINT_URL": "https://sfo3.digitaloceanspaces.com"
    }
}
```